### PR TITLE
Feature: single line mulit roll

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,10 @@
-name: Rust
+name: CI
 
 on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ * ]
+    branches: [ "*" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ * ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Current commands implemented
   ~help - not useful yet. 
 
   example ~roll commands:
+  
     ~roll 1D20  -> will roll one D20.
     ~roll 1D20 -7  -> will roll one D20 and also display rol lresult with a -7.
     ~roll 20D7 +2  -> will roll twenty D7's each with its roll result and a total added with 2.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Current commands implemented
     ~roll 20D7 +2  -> will roll twenty D7's each with its roll result and a total added with 2.
     ~roll 1D20 -7 +2 -> will roll one D20 and add the result with -5.
     ~roll 100D100 -a -> will show a line with the total added result of all rolls and another line showing the average.
+    ~roll 1D20 +7 2D8 -2 -> rolls two seperate dice where all modifiers will be added to the dice to the left of it.
   
   
   

--- a/src/commands/roll.rs
+++ b/src/commands/roll.rs
@@ -29,28 +29,37 @@ fn roll(ctx: &mut Context, msg: &Message) -> CommandResult {
         print_string = format!("{:?}", r.err().unwrap());
     } else {
         let tuple_return = r.ok().unwrap();
-        let num_roll = tuple_return.0;
-        let dice_type = tuple_return.1;
-        let add_on = tuple_return.2;
-        let args = tuple_return.3;
+        let dice_vector = tuple_return.0;
+        let arg_vector = tuple_return.1;
 
-        println!("{}", num_roll);
-
-        for character in args {
+        for character in arg_vector {
             if character == 'a' {
                 a_flag = true;
             }
         }
-        if a_flag {
-            print_string = roller::avg_roller(num_roll, dice_type, add_on);
-        } else if num_roll > MAX_PRINT_LINE_NUM {
-            print_string = format!(
-                "{}{}",
-                MAX_PRINT_LINE_MSG.to_string(),
-                roller::avg_roller(num_roll, dice_type, add_on)
-            );
-        } else {
-            print_string = roller::print_all_rolls(num_roll, dice_type, add_on);
+
+        println!("{}", dice_vector.len());
+
+        for dice in dice_vector {
+            if a_flag {
+                print_string.push_str(&roller::avg_roller(
+                    dice.number_rolls,
+                    dice.dice_type,
+                    dice.modifier,
+                ));
+            } else if dice.number_rolls > MAX_PRINT_LINE_NUM {
+                print_string.push_str(&format!(
+                    "{}{}",
+                    MAX_PRINT_LINE_MSG.to_string(),
+                    roller::avg_roller(dice.number_rolls, dice.dice_type, dice.modifier)
+                ));
+            } else {
+                print_string.push_str(&roller::print_all_rolls(
+                    dice.number_rolls,
+                    dice.dice_type,
+                    dice.modifier,
+                ));
+            }
         }
     }
 

--- a/src/core/dice.rs
+++ b/src/core/dice.rs
@@ -1,0 +1,6 @@
+#[derive(Copy, Clone)]
+pub struct Dice {
+    pub number_rolls: u32,
+    pub dice_type: u32,
+    pub modifier: i32,
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
+pub mod dice;
 pub mod parse;
 pub mod roller;


### PR DESCRIPTION
Commands like ~roll 1D20 2D8 now work. 

Changes
  Any modifier commands now need to have a dice roll beforehand
    eg: ~roll +7 1D20 will not work
  Dice struct created
  parse now returns a Vec<Dice>